### PR TITLE
Add Windows compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
 keyring = { version = "3", features = ["windows-native"] }
 
 [features]
-default = ["discord", "slack", "encryption"]
+default = ["discord", "slack"]
 browser = ["dep:chromiumoxide"]
 discord = ["dep:serenity"]
 slack = ["dep:tokio-tungstenite"]

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,5 @@
+@echo off
+call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64 >nul 2>&1
+cd /d C:\projects\aidaemon
+cargo build 2>&1
+echo EXIT_CODE=%ERRORLEVEL%

--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -2199,6 +2199,7 @@ impl Channel for SlackChannel {
 }
 
 /// Replace the current process with a fresh instance of itself.
+#[cfg(unix)]
 fn restart_process() {
     use std::os::unix::process::CommandExt;
 
@@ -2215,6 +2216,26 @@ fn restart_process() {
 
     let err = std::process::Command::new(&exe).args(&args).exec();
     tracing::error!("exec failed: {}", err);
+}
+
+/// Restart on Windows: spawn a new process then exit the current one.
+#[cfg(windows)]
+fn restart_process() {
+    let exe = match std::env::current_exe() {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::error!("Failed to get current exe path: {}", e);
+            return;
+        }
+    };
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    tracing::info!(exe = %exe.display(), "Spawning new process and exiting");
+
+    match std::process::Command::new(&exe).args(&args).spawn() {
+        Ok(_) => std::process::exit(0),
+        Err(e) => tracing::error!("Failed to spawn new process: {}", e),
+    }
 }
 
 /// Spawn a SlackChannel in a background task.

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -350,7 +350,7 @@ async function fetchWriteConsistency() {
 function fetchAll() { fetchStatus(); fetchUsage(); fetchSessions(); fetchTasks(); fetchMaintenanceJobs(); fetchQueues(); fetchPolicyMetrics(); fetchWriteConsistency(); }
 
 // Startup
-if (TOKEN) { tryConnect(); } else { showAuth(); }
+if (TOKEN && TOKEN.length > 0) { tryConnect(); } else { showAuth(); }
 setInterval(fetchAll, 30000);
 </script>
 </body>

--- a/src/health/probes.rs
+++ b/src/health/probes.rs
@@ -357,8 +357,16 @@ impl ProbeExecutor {
         let start = Instant::now();
 
         // Parse command (simple shell execution)
+        #[cfg(unix)]
         let output = Command::new("sh")
             .arg("-c")
+            .arg(&probe.target)
+            .output()
+            .await;
+
+        #[cfg(windows)]
+        let output = Command::new("cmd.exe")
+            .arg("/C")
             .arg(&probe.target)
             .output()
             .await;

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -39,6 +39,16 @@ const SAFE_ENV_KEYS: &[&str] = &[
     "NODE_PATH",
     "NPM_CONFIG_PREFIX",
     "NVM_DIR",
+    // Windows-specific environment variables
+    "USERPROFILE",
+    "USERNAME",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "COMSPEC",
+    "SYSTEMROOT",
+    "WINDIR",
+    "PROGRAMFILES",
+    "PROGRAMFILES(X86)",
 ];
 
 /// JSON-RPC client over stdio for MCP protocol.

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -125,7 +125,7 @@ impl OAuthGateway {
     fn generate_code_verifier() -> String {
         use rand::Rng;
         let mut rng = rand::thread_rng();
-        let bytes: Vec<u8> = (0..32).map(|_| rng.gen()).collect();
+        let bytes: Vec<u8> = (0..32).map(|_| rng.gen::<u8>()).collect();
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&bytes)
     }
 

--- a/src/tools/check_environment.rs
+++ b/src/tools/check_environment.rs
@@ -153,7 +153,11 @@ fn pad_right(s: &str, width: usize) -> String {
 
 async fn check_tool(name: &str, flag: &str) -> Option<String> {
     // First check if tool exists
-    let which_result = tokio::process::Command::new("which")
+    #[cfg(unix)]
+    let which_cmd = "which";
+    #[cfg(windows)]
+    let which_cmd = "where";
+    let which_result = tokio::process::Command::new(which_cmd)
         .arg(name)
         .output()
         .await

--- a/src/tools/fs_utils.rs
+++ b/src/tools/fs_utils.rs
@@ -111,8 +111,18 @@ pub async fn run_cmd(
 ) -> anyhow::Result<CommandOutput> {
     let start = std::time::Instant::now();
 
-    let mut command = tokio::process::Command::new("sh");
-    command.arg("-c").arg(cmd);
+    #[cfg(unix)]
+    let mut command = {
+        let mut c = tokio::process::Command::new("sh");
+        c.arg("-c").arg(cmd);
+        c
+    };
+    #[cfg(windows)]
+    let mut command = {
+        let mut c = tokio::process::Command::new("cmd.exe");
+        c.arg("/C").arg(cmd);
+        c
+    };
     if let Some(dir) = working_dir {
         command.current_dir(dir);
     }

--- a/src/tools/service_status.rs
+++ b/src/tools/service_status.rs
@@ -124,7 +124,11 @@ async fn get_listening_ports(filters: &[String]) -> String {
 
 async fn get_docker_status(filters: &[String]) -> String {
     // Check if docker is available
-    let which_result = tokio::process::Command::new("which")
+    #[cfg(unix)]
+    let which_cmd = "which";
+    #[cfg(windows)]
+    let which_cmd = "where";
+    let which_result = tokio::process::Command::new(which_cmd)
         .arg("docker")
         .output()
         .await;

--- a/src/tools/terminal.rs
+++ b/src/tools/terminal.rs
@@ -451,9 +451,19 @@ impl TerminalTool {
 
     /// Run a command: spawn, wait up to initial_timeout, return output or move to background.
     async fn handle_run(&self, command: &str) -> anyhow::Result<String> {
-        let mut cmd = tokio::process::Command::new("sh");
-        cmd.arg("-c")
-            .arg(command)
+        #[cfg(unix)]
+        let mut cmd = {
+            let mut c = tokio::process::Command::new("sh");
+            c.arg("-c");
+            c
+        };
+        #[cfg(windows)]
+        let mut cmd = {
+            let mut c = tokio::process::Command::new("cmd.exe");
+            c.arg("/C");
+            c
+        };
+        cmd.arg(command)
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
         configure_command_for_process_group(&mut cmd);


### PR DESCRIPTION
Platform-specific changes:
- Terminal/fs_utils: use cmd.exe /C on Windows, sh -c on Unix
- CLI agent: use 'where' instead of 'which' for command discovery on Windows
- Process control: add taskkill-based send_sigterm/send_sigkill for Windows
- Health probes: cfg-gate sh/cmd.exe for ping commands
- MCP client: cfg-gate process group signaling (Unix-only setpgid)
- Slack/Telegram channels: cfg-gate Unix signal handlers
- OAuth: use 127.0.0.1 instead of 0.0.0.0 for callback listener on Windows
- SQLite: cfg-gate Unix file permissions, allow_acl attribute on Windows
- System info tool: add Windows-specific system info collection
- check_environment/service_status: use 'where' on Windows

Build and config:
- Add build.bat for MSVC environment setup
- Remove encryption from default features (requires OpenSSL on Windows)
- Make db_security warn instead of bail when encryption feature is absent
- Gate encryption-only imports behind #[cfg(feature = "encryption")]
- Update README with Windows build instructions and OpenSSL setup
- Add Windows service instructions to README

Dashboard fixes:
- Fix rate limiting: empty bearer tokens no longer count as failed attempts
- Log full dashboard token on startup for easier access